### PR TITLE
Add pydantic.mypy plugin to mypy configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ markers = ["integrate: integration test"]
 [tool.mypy]
 warn_return_any = true
 warn_unused_configs = true
+plugins = "pydantic.mypy"
 
 [[tool.mypy.overrides]]
 module = "sshkeyboard"

--- a/simple_typing_application/sentence_generator/openai_sentence_generator.py
+++ b/simple_typing_application/sentence_generator/openai_sentence_generator.py
@@ -22,17 +22,20 @@ class OpenaiSentenceGenerator(BaseSentenceGenerator):
         self,
         model: str = 'gpt-3.5-turbo-16k',
         temperature: float = .7,
-        openai_api_key: SecretStr | None = None,
+        openai_api_key: SecretStr | str | None = None,
         memory_size: int = 1,
         max_retry: int = 5,
         logger: Logger = getLogger(__name__),
     ):
         self._max_retry = max_retry
-
         self._llm = ChatOpenAI(
             model=model,
             temperature=temperature,
-            api_key=openai_api_key,
+            openai_api_key=(
+                openai_api_key.get_secret_value()  # type: ignore
+                if hasattr(openai_api_key, 'get_secret_value') else
+                openai_api_key
+            ),
         )
         self._memory = ConversationBufferMemory(k=memory_size)  # type: ignore  # noqa
         self._chain = ConversationChain(llm=self._llm, memory=self._memory)  # type: ignore  # noqa


### PR DESCRIPTION
This pull request adds the pydantic.mypy plugin to the mypy configuration. This plugin will enhance the type checking capabilities of mypy and improve the accuracy of type inference.

This pull request also fixes the following bug:

```bash
 $ python -m simple_typing_application -c config.json
Traceback (most recent call last):
  File "~\.pyenv\pyenv-win\versions\3.10.11\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "~\.pyenv\pyenv-win\versions\3.10.11\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "D:\dev_libs\simple_typing_application\simple_typing_application\__main__.py", line 2, in <module>
    main()
  File "D:\dev_libs\simple_typing_application\venv\lib\site-packages\click\core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "D:\dev_libs\simple_typing_application\venv\lib\site-packages\click\core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "D:\dev_libs\simple_typing_application\venv\lib\site-packages\click\core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "D:\dev_libs\simple_typing_application\venv\lib\site-packages\click\core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "D:\dev_libs\simple_typing_application\simple_typing_application\main.py", line 45, in main
    sentence_generator = create_sentence_generator(config.sentence_generator_type, config.sentence_generator_config)  # noqa
  File "D:\dev_libs\simple_typing_application\simple_typing_application\sentence_generator\factory.py", line 51, in create_sentence_generator
    sentence_generator: BaseSentenceGenerator = sentence_generator_cls(**sentence_generator_config.model_dump())    # type: ignore # noqa
  File "D:\dev_libs\simple_typing_application\simple_typing_application\sentence_generator\openai_sentence_generator.py", line 32, in __init__
    self._llm = ChatOpenAI(
  File "D:\dev_libs\simple_typing_application\venv\lib\site-packages\langchain_core\load\serializable.py", line 120, in __init__
    super().__init__(**kwargs)
  File "D:\dev_libs\simple_typing_application\venv\lib\site-packages\pydantic\v1\main.py", line 341, in __init__
    raise validation_error
pydantic.v1.error_wrappers.ValidationError: 1 validation error for ChatOpenAI
api_key
  str type expected (type=type_error.str)
```