### PR TITLE
Update GitHub Actions workflows for adding tags on pull request closure and checking and fixing version on push tags

### DIFF
--- a/.github/workflows/add-tag-on-pull-request-by-bot.yaml
+++ b/.github/workflows/add-tag-on-pull-request-by-bot.yaml
@@ -7,11 +7,10 @@ on:
 jobs:
   add-tag:
     if: github.event.pull_request.merged == true
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Add Tag
-        shell: bash
         run: |
           # If the head of PR is "bot/update-version-to-<tag>", then the tag is <tag>
           if [[ ! ${{ github.head_ref }} =~ ^bot/update-version-to-.*$ ]]; then

--- a/.github/workflows/check-and-fix-version-on-push-tags.yaml
+++ b/.github/workflows/check-and-fix-version-on-push-tags.yaml
@@ -13,7 +13,7 @@ jobs:
   update-version:
     needs: [validate-tag]
     if: ${{ failure() }}
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -24,7 +24,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Update Tags
-        shell: bash
         run: |
           # Get the latest tag
           export latest_tag=$(git describe --tags --abbrev=0)


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to add tags on pull request closure and to check and fix the version on push tags. The workflows have been modified to run on Ubuntu instead of Windows.