### PR TITLE
Fix permissions for update-version job in GitHub Actions workflow

### DIFF
--- a/.github/workflows/check-and-fix-version-on-push-tags.yaml
+++ b/.github/workflows/check-and-fix-version-on-push-tags.yaml
@@ -14,6 +14,9 @@ jobs:
       contents: write
       pull-requests: write
   update-version:
+    permissions:
+      contents: write
+      pull-requests: write
     needs: [validate-tag]
     if: ${{ failure() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ensure the update-version job has the necessary permissions to write contents and pull requests in the GitHub Actions workflow.